### PR TITLE
bump: nextjs-toploader version to 1.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "flowbite-react": "^0.4.4",
     "js-cookie": "^3.0.1",
     "next": "13.4.9",
-    "nextjs-toploader": "^1.6.4",
+    "nextjs-toploader": "^1.6.6",
     "react": "^18",
     "react-day-picker": "^8.5.1",
     "react-dom": "^18",


### PR DESCRIPTION
Fixes #1 